### PR TITLE
Make status bar item shorter and clickable.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,8 +9,8 @@ import fs from 'fs';
 const tracker: TimeTracker = new TimeTracker();
 let statusBarItem: vscode.StatusBarItem;
 
-const ICON_STARTED = '$(debug-start)';
-const ICON_STOPPED = '$(debug-stop)';
+const ICON_STARTED = '$(watch)';
+const ICON_STOPPED = '';
 const ICON_PAUSED = '$(debug-pause)';
 
 const COMMAND_START = "timetracker.start"
@@ -127,7 +127,7 @@ function updateStatusBarItem(timeTracker: TimeTracker) {
 		const currentSessionTime = moment.duration(currentSessionSeconds, 's').format('hh:mm:ss', { trim: false });
 		const totalTime = moment.duration(totalSeconds, 's').format('hh:mm', { trim: false });
 
-		statusBarItem.text = `${icon} ${totalTime}+${currentSessionTime}`;
+		statusBarItem.text = `${icon}${totalTime}+${currentSessionTime}`;
 		statusBarItem.tooltip = `State: ${state} Total: ${totalTime} Current session: ${currentSessionTime}`;
 		statusBarItem.command = timeTracker.state === TimeTrackerState.Started ? COMMAND_STOP : COMMAND_START;
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,14 +13,17 @@ const ICON_STARTED = '$(debug-start)';
 const ICON_STOPPED = '$(debug-stop)';
 const ICON_PAUSED = '$(debug-pause)';
 
+const COMMAND_START = "timetracker.start"
+const COMMAND_STOP = "timetracker.stop"
+
 export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
-		vscode.commands.registerCommand('timetracker.start', () => {
+		vscode.commands.registerCommand(COMMAND_START, () => {
 			if (tracker.start(updateStatusBarItem)) {
 				updateStatusBarItem(tracker);
 			}
 		}),
-		vscode.commands.registerCommand('timetracker.stop', () => {
+		vscode.commands.registerCommand(COMMAND_STOP, () => {
 			if (tracker.stop()) {
 				updateStatusBarItem(tracker);
 			}
@@ -124,7 +127,9 @@ function updateStatusBarItem(timeTracker: TimeTracker) {
 		const currentSessionTime = moment.duration(currentSessionSeconds, 's').format('hh:mm:ss', { trim: false });
 		const totalTime = moment.duration(totalSeconds, 's').format('hh:mm', { trim: false });
 
-		statusBarItem.text = `${icon} ${state}   Total: ${totalTime}   Current session: ${currentSessionTime}`;
+		statusBarItem.text = `${icon} ${totalTime}+${currentSessionTime}`;
+		statusBarItem.tooltip = `State: ${state} Total: ${totalTime} Current session: ${currentSessionTime}`;
+		statusBarItem.command = timeTracker.state === TimeTrackerState.Started ? COMMAND_STOP : COMMAND_START;
 	}
 }
 


### PR DESCRIPTION
1. click to start/stop
2. shorter: 
  - stoped: ![捕获](https://user-images.githubusercontent.com/4396864/102438894-2a8b3d00-4058-11eb-9e54-7ad806689439.PNG)
  - started: ![ScreenClip](https://user-images.githubusercontent.com/4396864/102438926-34ad3b80-4058-11eb-9f34-08fdc28f3a22.png)
  - paused: ![捕获2](https://user-images.githubusercontent.com/4396864/102438952-3e36a380-4058-11eb-927f-61b4a15e6222.PNG)




